### PR TITLE
remove duplicate call to confirmCardPayment for payment request

### DIFF
--- a/cards-and-mobile-wallets/client/elementsModal.js
+++ b/cards-and-mobile-wallets/client/elementsModal.js
@@ -473,8 +473,7 @@
       _elementsModal_stripe
         .confirmCardPayment(
           paymentIntent.client_secret,
-          { payment_method: ev.paymentMethod.id },
-          { handleActions: false }
+          { payment_method: ev.paymentMethod.id }
         )
         .then(function(confirmResult) {
           if (confirmResult.error) {
@@ -482,25 +481,15 @@
             // re-show the payment interface, or show an error message and close
             // the payment interface.
             ev.complete("fail");
+            var displayError = document.getElementById(
+              "paymentRequest-errors"
+            );
+            displayError.textContent = confirmResult.error.message;
           } else {
             // Report to the browser that the confirmation was successful, prompting
             // it to close the browser payment method collection interface.
             ev.complete("success");
-            // Let Stripe.js handle the rest of the payment flow.
-            _elementsModal_stripe
-              .confirmCardPayment(paymentIntent.client_secret)
-              .then(function(result) {
-                if (result.error) {
-                  // The payment failed -- ask your customer for a new payment method.
-                  var displayError = document.getElementById(
-                    "paymentRequest-errors"
-                  );
-                  displayError.textContent = result.error.message;
-                } else {
-                  // The payment has succeeded.
-                  stripePaymentHandler();
-                }
-              });
+            stripePaymentHandler();
           }
         });
     });


### PR DESCRIPTION
👋 hello

When I ran the Cards and Mobile Wallets demo, I saw that the second call to `confirmCardPayment` failed with a 400. The error message suggests that `confirmCardPayment` is a call-once method in order to finalise the payment. The error is pasted below:

<details>
    <summary>open for error</summary>
<pre>
{
  "error": {
    "code": "payment_intent_unexpected_state",
    "doc_url": "https://stripe.com/docs/error-codes/payment-intent-unexpected-state",
    "message": "You cannot confirm this PaymentIntent because it has already succeeded after being previously confirmed.",
    "payment_intent": {
      "id": "pi_123",
      "object": "payment_intent",
      "amount": 1999,
      "canceled_at": null,
      "cancellation_reason": null,
      "capture_method": "automatic",
      "client_secret": "pi_123_secret_567",
      "confirmation_method": "automatic",
      "created": 1578354827,
      "currency": "usd",
      "description": null,
      "last_payment_error": null,
      "livemode": false,
      "next_action": null,
      "payment_method": "pm_789",
      "payment_method_types": [
        "card"
      ],
      "receipt_email": null,
      "setup_future_usage": null,
      "shipping": null,
      "source": null,
      "status": "succeeded"
    },
    "type": "invalid_request_error"
  }
}
</pre>
</details>

I removed the second call and consolidated the `success` and `fail` handling. 

Have a great day 🌻 