### PR TITLE
exit early out of payment method handler if payment is already in succeeded status

### DIFF
--- a/cards-and-mobile-wallets/client/elementsModal.js
+++ b/cards-and-mobile-wallets/client/elementsModal.js
@@ -486,7 +486,9 @@
             // Report to the browser that the confirmation was successful, prompting
             // it to close the browser payment method collection interface.
             ev.complete("success");
-            // Let Stripe.js handle the rest of the payment flow.
+            // Check if payment has fully succeeded and no futher action is needed
+            if (confirmResult.paymentIntent.status === "succeeded") return stripePaymentHandler();
+            // Otherwise, let Stripe.js handle the rest of the payment flow (eg. 3DS authentication is required).
             _elementsModal_stripe
               .confirmCardPayment(paymentIntent.client_secret)
               .then(function(result) {


### PR DESCRIPTION
👋 trying again!

This PR alters the code to only make the second call to `confirmCardPayment` if it's absolutely necessary. This means that developers won't be confused about the `400` error that might show up if further action is not needed on the `PaymentIntent`.

Thanks! 🙇 